### PR TITLE
Install claude-mem plugin for persistent memory across sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "plugins": {
+        "thedotmack/claude-mem": true
+    }
+}


### PR DESCRIPTION
- Installed claude-mem v10.5.5 globally via npm
- Configured plugin hooks in ~/.claude/settings.json (Setup, SessionStart, UserPromptSubmit, PostToolUse, Stop)
- Symlinked plugin to ~/.claude/plugins/marketplaces/thedotmack/plugin
- Added skills: do, make-plan, mem-search, smart-explore
- Added project-level .claude/settings.json to enable claude-mem plugin

https://claude.ai/code/session_013747mUQHTe3JvsY4nS9fTa